### PR TITLE
Support for Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Script for testing your code with the sample data files provided by Kattis, Code
 * C
 * C#
 * C++
+* Haskell
 * Java
 * Python 3
 

--- a/kattest/languages.py
+++ b/kattest/languages.py
@@ -66,3 +66,17 @@ def cSharp(filename, inputs):
     except:
         pass
     return output, endTime
+
+def haskell(filename, inputs):
+    output = {}
+    problem = filename.split(".")[0]
+    check_output(["ghc", "-dynamic", "-O2", filename, "-o", problem])
+    startTime = time.time()
+    for input in inputs:
+        output[input] = check_output([f"./{problem}"], input=input, universal_newlines=True)
+    endTime = time.time() - startTime
+    try:
+        check_output(["rm", "-rf", f"{problem}.hi", f"{problem}.o", f"{problem}"])
+    except:
+        pass
+    return output, endTime

--- a/kattest/script.py
+++ b/kattest/script.py
@@ -1,4 +1,4 @@
-from kattest.languages import python, cpp, c, java, cSharp
+from kattest.languages import python, cpp, c, java, cSharp, haskell
 from kattest.data import Kattis, CF, CSES
 import emoji
 import sys
@@ -25,6 +25,8 @@ def kattest(filename, site):
         output, time = java(filename, testdata)
     elif extension == "cs":
         output, time = cSharp(filename, testdata)
+    elif extension == "hs":
+        output, time = haskell(filename, testdata)
     else:
         print("Language is not supported :(")
         return -1


### PR DESCRIPTION
Compiling, testing and cleaning up Haskell code in the same way as the
other compiled languages that are supported.
A fairly straightforward change.

Specifically compiling a dynamically linked binary with optimization level 2
(-O2 does not seem as important as in gcc, but should have some effect)

This change was tested with a simple hello world solution – testing and cleanup works as expected.