### PR TITLE
Upgrade emoji package

### DIFF
--- a/kattest/script.py
+++ b/kattest/script.py
@@ -36,13 +36,13 @@ def kattest(args):
         if formatter(user) == formatter(correct):
             if not quiet:
                 print(
-                    f'{emoji.emojize(":white_check_mark:", use_aliases=True)} Sample Input {counter}'
+                    f'{emoji.emojize(":white_check_mark:", language="alias")} Sample Input {counter}'
                 )
             correct_count += 1
         else:
             if not quiet:
                 print(
-                    f'{emoji.emojize(":x:", use_aliases=True)} Sample Input {counter}'
+                    f'{emoji.emojize(":x:", language="alias")} Sample Input {counter}'
                 )
         if not quiet:
             print("INPUT")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-emoji==0.6.0
+emoji==2.2.0
 beautifulsoup4==4.9.3


### PR DESCRIPTION
Upgrade emoji package and replace deprecated emoji.emojize parameter 'use_aliases' with 'language'.

Before upgrade, when running `kattest --site Kattis --problem hello --filepath test.py `, I received the following error:

```
throws error:
Traceback (most recent call last):
  File "kattest", line 33, in <module>
    sys.exit(load_entry_point('kattest==1.7', 'console_scripts', 'kattest')())
  File "kattest/__main__.py", line 30, in main
    kattest(args)
  File "kattest/script.py", line 39, in kattest
    f'{emoji.emojize(":white_check_mark:", use_aliases=True)} Sample Input {counter}'
TypeError: emojize() got an unexpected keyword argument 'use_aliases'
```